### PR TITLE
Include text attachments when parsing payload

### DIFF
--- a/lib/gmailpush.js
+++ b/lib/gmailpush.js
@@ -342,6 +342,7 @@ Gmailpush.prototype = {
       payload.mimeType.startsWith('video/') ||
       payload.mimeType.startsWith('application/') ||
       payload.mimeType.startsWith('font/') ||
+      payload.mimeType.startsWith('text/') ||
       payload.mimeType.startsWith('model/')
     ) {
       parsedMessage.attachments.push({


### PR DESCRIPTION
Text attachments, like CSV files, are currently ignored. This addition includes them. It shouldn't interfere with parsing the body from the payload because this is all in an `else if` clause